### PR TITLE
Preserve tag kind

### DIFF
--- a/lib/Plugin/GhcTags/Generate.hs
+++ b/lib/Plugin/GhcTags/Generate.hs
@@ -9,10 +9,10 @@
 module Plugin.GhcTags.Generate
   ( GhcTag (..)
   , GhcTags
-  , TagKind (..)
+  , GhcKind (..)
   , TagField (..)
-  , tagKindToChar
-  , charToTagKind
+  , ghcKindToChar
+  , charToGhcKind
   , getGhcTags
   ) where
 
@@ -77,7 +77,7 @@ import           Name         ( nameOccName
 
 -- | `ctags` can generate tags kind, so do we.
 --
-data TagKind = TkTerm
+data GhcKind = TkTerm
              | TkFunction
              | TkTypeConstructor
              | TkDataConstructor
@@ -98,8 +98,8 @@ data TagKind = TkTerm
   deriving (Ord, Eq, Show)
 
 
-tagKindToChar :: TagKind -> Char
-tagKindToChar tagKind = case tagKind of
+ghcKindToChar :: GhcKind -> Char
+ghcKindToChar tagKind = case tagKind of
     TkTerm                    -> '`'
     TkFunction                -> 'λ'
     TkTypeConstructor         -> 'Λ'
@@ -120,8 +120,8 @@ tagKindToChar tagKind = case tagKind of
     TkForeignExport           -> 'E'
 
 
-charToTagKind :: Char -> Maybe TagKind
-charToTagKind c = case c of
+charToGhcKind :: Char -> Maybe GhcKind
+charToGhcKind c = case c of
      '`' -> Just TkTerm
      'λ' -> Just TkFunction
      'Λ' -> Just TkTypeConstructor
@@ -160,7 +160,7 @@ fileField = TagField { fieldName = "file", fieldValue = "" }
 data GhcTag = GhcTag {
     gtSrcSpan  :: !SrcSpan
   , gtTag      :: !FastString
-  , gtKind     :: !TagKind
+  , gtKind     :: !GhcKind
   , gtFields   :: ![TagField]
   }
   deriving Show
@@ -187,7 +187,7 @@ getFileTagField (Just ies) name =
 
 mkGhcTag :: Located RdrName
          -- ^ @RdrName ~ IdP GhcPs@ it *must* be a name of a top level identifier.
-         -> TagKind
+         -> GhcKind
          -- ^ tag's kind
          -> [TagField]
          -- ^ tag's fields
@@ -251,7 +251,7 @@ getGhcTags (L _ HsModule { hsmodDecls, hsmodExports }) =
     -- like 'mkGhcTag' but checks if the identifier is exported
     mkGhcTag' :: Located RdrName
               -- ^ @RdrName ~ IdP GhcPs@ it *must* be a name of a top level identifier.
-              -> TagKind
+              -> GhcKind
               -- ^ tag's kind
               -> GhcTag
     mkGhcTag' a k = mkGhcTag a k (maybeToList $ getFileTagField mies a)

--- a/lib/Plugin/GhcTags/Vim/Formatter.hs
+++ b/lib/Plugin/GhcTags/Vim/Formatter.hs
@@ -34,14 +34,21 @@ formatTag Tag { tagName, tagFile, tagAddr, tagKind, tagFields} =
     <> BS.stringUtf8 ";\""
     -- tag kind: we are encoding them using field syntax: this is because vim
     -- is using them in the right way: https://github.com/vim/vim/issues/5724
-    <> foldMap (formatKindChar . tagKindToChar) tagKind
+    <> formatKindChar tagKind
     -- tag fields
     <> foldMap ((BS.charUtf8 '\t' <>) . formatField) tagFields 
     <> BS.charUtf8 '\n'
   where
-    formatKindChar :: Char -> Builder
-    formatKindChar c | isAscii c = BS.charUtf8 '\t' <> BS.charUtf8 c
+    formatKindChar :: TagKind -> Builder
+    formatKindChar NoKind = mempty
+    formatKindChar (CharKind c)
+                     | isAscii c = BS.charUtf8 '\t' <> BS.charUtf8 c
                      | otherwise = BS.stringUtf8 "\tkind:" <> BS.charUtf8 c
+    formatKindChar (GhcKind ghcKind)
+                     | isAscii c = BS.charUtf8 '\t' <> BS.charUtf8 c
+                     | otherwise = BS.stringUtf8 "\tkind:" <> BS.charUtf8 c
+      where
+        c = ghcKindToChar ghcKind
 
 
 formatField :: TagField -> Builder

--- a/lib/Plugin/GhcTags/Vim/Parser.hs
+++ b/lib/Plugin/GhcTags/Vim/Parser.hs
@@ -52,7 +52,7 @@ parseTag =
 
           -- list of fields (kind field might be later, but don't check it, we
           -- always format it as the first field) or end of line.
-          <|> (Nothing,)
+          <|> (NoKind,)
                 <$> ( separator *> parseFields <* AT.endOfLine
                       <|>
                       AT.endOfLine $> []
@@ -66,7 +66,7 @@ parseTag =
                         <|>
                         AT.endOfLine $> []
                       )
-          <|> AT.endOfLine $> (Nothing, [])
+          <|> AT.endOfLine $> (NoKind, [])
         )
 
   where
@@ -102,13 +102,19 @@ parseTag =
                   AT.endOfLine
                   (AT.char ';' *> AT.char '"')
 
-    parseKindField :: Parser (Maybe TagKind)
+    parseKindField :: Parser TagKind
     parseKindField =
       charToTagKind <$>
         (AT.string "kind:" *> AT.satisfy notTabOrNewLine)
 
     parseFields :: Parser [TagField]
     parseFields = AT.sepBy parseField separator
+
+
+charToTagKind :: Char -> TagKind
+charToTagKind c = case charToGhcKind c of
+    Nothing      -> CharKind c
+    Just ghcTag  -> GhcKind  ghcTag
 
 
 parseField :: Parser TagField

--- a/test/Test/Golden/Parser.hs
+++ b/test/Test/Golden/Parser.hs
@@ -24,8 +24,6 @@ tests = testGroup "Golden.Parser"
          output
          (parseGoldenFile input output)
 
-  -- we are dropping tag kinds which we don't recognize
-  {-
   , let input  = "test/golden/vim.tags"
         output = "test/golden/vim.tags.out"
     in goldenVsFile 
@@ -33,7 +31,6 @@ tests = testGroup "Golden.Parser"
          input
          output
          (parseGoldenFile input output)
-  -}
 
   , let input  = "test/golden/typed-protocols.tags"
         output = "test/golden/typed-protocols.tags.out"


### PR DESCRIPTION
When parsing a tag file we may not recognize the kind, in this case we
store it.  This allows us to preserve original information.

This patch enabled golden test for parsing and formatting ctags
generated tags file (for `vim` project).