### PR TITLE
Removed TupleSections extension

### DIFF
--- a/lib/Plugin/GhcTags/Vim/Parser.hs
+++ b/lib/Plugin/GhcTags/Vim/Parser.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TupleSections              #-}
 
 -- | Parser combinators for vim style tags
 --
@@ -52,7 +51,7 @@ parseTag =
 
           -- list of fields (kind field might be later, but don't check it, we
           -- always format it as the first field) or end of line.
-          <|> (NoKind,)
+          <|> curry id NoKind
                 <$> ( separator *> parseFields <* AT.endOfLine
                       <|>
                       AT.endOfLine $> []


### PR DESCRIPTION
One can use `curry id a` or `flip (curry id) b` for either `(a,)` or
`(,b)`.  Adding just for fun of it.