### PR TITLE
Use canonical paths for tags directories

### DIFF
--- a/ghc-tags-plugin.cabal
+++ b/ghc-tags-plugin.cabal
@@ -70,6 +70,7 @@ test-suite ghc-tags-tests
   build-depends:       attoparsec,
                        base,
                        bytestring,
+                       lattices,
                        QuickCheck,
                        quickcheck-instances,
                        tasty,

--- a/lib/Plugin/GhcTags/Tag.hs
+++ b/lib/Plugin/GhcTags/Tag.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BangPatterns               #-}
 {-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE OverloadedStrings          #-}
@@ -54,13 +53,13 @@ import           Plugin.GhcTags.Generate
 -- | 'ByteString' which encodes a tag name.
 --
 newtype TagName = TagName { getTagName :: Text }
-  deriving newtype (Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 
 -- | 'ByteString' which encodes a tag file.
 --
 newtype TagFile = TagFile { getTagFile :: String }
-  deriving newtype (Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 
 -- | When we parse a `tags` file we can eithera find no kind or recognize the

--- a/src/Plugin/GhcTags.hs
+++ b/src/Plugin/GhcTags.hs
@@ -145,9 +145,9 @@ updateTags tagsFile lmodule =
                   return $ mkTagsMap tagList
 
         cwd <- getCurrentDirectory
-        -- absolute directory path of the tags file
-        -- we need absolute path to make all tags file relative to it.
-        tagsDir <- makeAbsolute (fst $ splitFileName tagsFile)
+        -- absolute directory path of the tags file; we need canonical path
+        -- (without ".." and ".") to make 'makeRelative' works.
+        tagsDir <- canonicalizePath (fst $ splitFileName tagsFile)
 
         let tagsMap' :: TagsMap
             tagsMap' =

--- a/test/Test/Tag.hs
+++ b/test/Test/Tag.hs
@@ -35,16 +35,18 @@ newtype ArbOrdTag = ArbOrdTag { getArbOrdTag :: Tag }
 instance Arbitrary ArbOrdTag where
     arbitrary = fmap ArbOrdTag
               $  Tag
-             <$> elements (TagName `map`
-                       [ "find"
-                       , "Ord"
-                       , "Eq"
-                       ])
+             <$> elements
+                   (TagName `map`
+                     [ "find"
+                     , "Ord"
+                     , "Eq"
+                     ])
              <*> genTagKind
-             <*> elements (TagFile `map`
-                       [ "Main.hs"
-                       , "Lib.hs"
-                       ])
+             <*> elements
+                   (TagFile `map`
+                     [ "Main.hs"
+                     , "Lib.hs"
+                     ])
              <*> frequency
                    [ (8, Left . getPositive <$> arbitrary)
                    , (1, Right . (wrap '/' . fixAddr) <$> genTextNonEmpty)

--- a/test/Test/Tag.hs
+++ b/test/Test/Tag.hs
@@ -39,7 +39,6 @@ instance Arbitrary ArbOrdTag where
                        [ "find"
                        , "Ord"
                        , "Eq"
-                       , "hPut"
                        ])
              <*> genTagKind
              <*> elements (TagFile `map`

--- a/test/Test/Tag/Generators.hs
+++ b/test/Test/Tag/Generators.hs
@@ -8,6 +8,8 @@ import           Data.Maybe (isNothing)
 import           Data.Text   (Text)
 import qualified Data.Text as Text
 
+import           Algebra.Lattice
+
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances.Text ()
 
@@ -27,10 +29,12 @@ genTextNonEmpty =
 -- filter only printable characters, removing tabs and newlines which have
 -- special role in vim tag syntax
 fixText :: Text -> Text
-fixText = Text.filter (\x -> x /= '\t' && x /= '\n' && Char.isPrint x)
+fixText = Text.filter ( ((/= Char.Control) . Char.generalCategory)
+                        /\ Char.isPrint)
 
 fixFilePath :: String -> String
-fixFilePath = List.filter (\x -> x /= '\t' && x /= '\n' && Char.isPrint x)
+fixFilePath = List.filter ( ((/= Char.Control) . Char.generalCategory)
+                            /\ Char.isPrint)
 
 genFilePath :: Gen String
 genFilePath =
@@ -50,7 +54,9 @@ genField =
 -- filter only printable characters, removing tabs, newlines and colons which
 -- have special role in vim field syntax
 fixFieldText :: Text -> Text
-fixFieldText = Text.filter (\x -> x /= '\t' && x /= ':' && x /= '\n' && Char.isPrint x)
+fixFieldText = Text.filter ( (/= ':')
+                             /\ ((/= Char.Control) . Char.generalCategory)
+                             /\ Char.isPrint)
 
 
 -- address cannot contain ";\"" sequence
@@ -90,13 +96,7 @@ genTagKind = oneof
     ]
   where
     genChar = suchThat arbitrary
-                       (\x ->    x /= '\t'
-                              && x /= '\n'
-                              && x /= ':'
-                              && x /= '\NUL'
-                              && isNothing (charToGhcKind x)
+                       ( ((/= Char.Control) . Char.generalCategory)
+                         /\ (/= ':')
+                         /\ (isNothing . charToGhcKind)
                        )
-
---
---
---


### PR DESCRIPTION
'makeRelative' works reliably when the path passed to it is in cannonical form.