### PR TITLE
Concurency safety - using exlusive advisory locks (BSD locks)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,7 @@ latest:
 recache:
 	ghc-pkg recache --package-db=${PACKAGE_DB}
 
-.PHONY: install, uninstall, reinstall, latest
+check:
+	ghc-pkg check --package-db=${PACKAGE_DB} 2>&1 | grep ghc-tags
+
+.PHONY: install, uninstall, reinstall, latest, check

--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,4 @@ latest:
 recache:
 	ghc-pkg recache --package-db=${PACKAGE_DB}
 
-.PHONY: install, uninstall, reinstall, show, latest
+.PHONY: install, uninstall, reinstall, latest

--- a/README.md
+++ b/README.md
@@ -143,6 +143,19 @@ ghc: panic! (the 'impossible' happened)
 
 ```
 
+● Tips
+------
+
+- The plugin is safe for concurrent compilation.  Setting `jobs: $ncpus` is
+  safe.  The plugin holds an exclusive (advisory) lock on the `tags` file.
+  This will create synchronisation between threads / process which are using
+  the same `tags` file.
+
+- If you are working on a larger project, it might be better to not collect all
+  tags in a single `tags` file, since at every compilation step one will need
+  to parse a large `tags` file.  Working with tag files of size 10000 tags (or
+  ~1.5MB) is ok - though this will depend on the hardware.
+
 
 ● Security implications of compiler plugins
 -------------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Ghc Tags Compiler Plugin
+Ghc Tags Compiler Plugin
+========================
 ![](https://github.com/coot/ghc-tags-plugin/workflows/GHC-8.8.3/badge.svg)
 ![](https://github.com/coot/ghc-tags-plugin/workflows/GHC-8.6.5/badge.svg)
 
@@ -6,13 +7,15 @@ A [Ghc Compiler Plugin](https://downloads.haskell.org/~ghc/latest/docs/html/user
 which generates tags for each compiled module or component.
 
 
-# ● Requirements
+● Requirements
+--------------
 
 ```
 ghc >= 8.6
 ```
 
-# ● Vim configuration
+● Vim configuration
+-------------------
 
 By default each generated tags file is put next to the corresponding `*.cabal`
 package file.  If you just have a repo with a cabal file in the main directory
@@ -24,7 +27,8 @@ subdirectories you will either need to set:
 or pass an option to modify where tags are written, see below.
 
 
-# ● Plugin options
+● Plugin options
+----------------
 
 The plugin accepts an only one option, which is a file path to the tags file.
 It can be an absolute path or relative (to the `*.cabal` package file rather
@@ -35,7 +39,8 @@ than `cabal.project` file), for example:
 This is useful if for *cabal packages* which are located in subdirectories.
 
 
-# ● Configuration: Ghc / Cabal / Stack
+● Configuration: Ghc / Cabal / Stack
+------------------------------------
 
 Configuration of this plugin requires some familiarity with `ghc` packages.
 Check out
@@ -123,7 +128,8 @@ contains some useful commands, e.g. `install`,  `uninstall` or `reinstall` the
 package in a `package.db` (by default into `cabal` store).  This is mostly for
 development, but it could be useful in other scenarios as well.
 
-# ● Exceptions
+● Exceptions
+------------
 
 If a `GHC` plugin throws an exception, `GHC` stops.  This plugin wraps
 `IOException`s, to make it obvious that it filed rather than `GHC`.  This
@@ -138,7 +144,8 @@ ghc: panic! (the 'impossible' happened)
 ```
 
 
-# ● Security implications of compiler plugins
+● Security implications of compiler plugins
+-------------------------------------------
 
 Such plugins can:
 

--- a/ghc-tags-plugin.cabal
+++ b/ghc-tags-plugin.cabal
@@ -29,8 +29,8 @@ library
   exposed-modules:     Plugin.GhcTags
   build-depends:       base          >=4.12.0.0 && <4.14,
                        bytestring   ^>=0.10,
-                       containers   ^>=0.6,
                        directory    ^>=1.3,
+                       filelock     ^>=0.1.1,
                        filepath     ^>=1.4,
                        ghc           >=8.4 && <8.9,
                        text         ^>=1.2,
@@ -53,7 +53,6 @@ library ghc-tags-library
   build-depends:       attoparsec   ^>=0.13.0.0,
                        base          >=4.12.0.0 && <4.14,
                        bytestring   ^>=0.10,
-                       containers   ^>=0.6,
                        directory    ^>=1.3,
                        ghc           >=8.4 && <8.9,
                        text         ^>=1.2

--- a/ghc-tags-plugin.cabal
+++ b/ghc-tags-plugin.cabal
@@ -18,9 +18,11 @@ homepage:            https://github.com/coot/ghc-tags-plugin#readme
 bug-reports:         https://github.com/coot/ghc-tags-plugin/issues
 tested-with:         GHC==8.6.3, GHC==8.8.3
 
+
 source-repository head
   type:     git
   location: https://github.com/coot/ghc-tags-plugin
+
 
 library
   hs-source-dirs:      src
@@ -37,6 +39,7 @@ library
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+
 
 library ghc-tags-library
   hs-source-dirs:      lib
@@ -57,6 +60,7 @@ library ghc-tags-library
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+
 
 test-suite ghc-tags-tests
   type:                exitcode-stdio-1.0


### PR DESCRIPTION
When a project is compiled concurrenlty we need to guard access to the tags
file.  We do so with an `flock` on unix and `LockFileEx` on windows (`filelock` library).
