### PR TITLE
path normalisation

### DIFF
--- a/ghc-tags-core/lib/GhcTags/CTag/Parser.hs
+++ b/ghc-tags-core/lib/GhcTags/CTag/Parser.hs
@@ -22,7 +22,7 @@ import           Data.Functor (void, ($>))
 import           Data.Maybe (catMaybes)
 import           Data.Text          (Text)
 import qualified Data.Text          as Text
-import           System.FilePath (FilePath, normalise)
+import           System.FilePath (FilePath)
 
 import           GhcTags.Tag
 import qualified GhcTags.Utils as Utils
@@ -35,7 +35,7 @@ parseTag :: Parser CTag
 parseTag =
       (\tagName tagFilePath tagAddr (tagKind, tagFields)
         -> Tag { tagName
-               , tagFilePath = normalise tagFilePath
+               , tagFilePath
                , tagAddr
                , tagKind
                , tagFields

--- a/ghc-tags-core/lib/GhcTags/ETag/Parser.hs
+++ b/ghc-tags-core/lib/GhcTags/ETag/Parser.hs
@@ -21,7 +21,7 @@ import qualified Data.Attoparsec.Text  as AT
 import           Data.Functor (($>))
 import           Data.Text (Text)
 import qualified Data.Text as Text
-import           System.FilePath (FilePath, normalise)
+import           System.FilePath (FilePath)
 
 import           GhcTags.Tag
 import qualified GhcTags.Utils as Utils
@@ -75,7 +75,7 @@ parseTag tagFilePath =
                               Nothing   -> TagName tagDefinition
                               Just name -> name
           , tagKind       = NoKind
-          , tagFilePath   = normalise tagFilePath
+          , tagFilePath
           , tagAddr       = TagLineCol lineNo byteOffset
           , tagDefinition = case mTagName of
                               Nothing -> NoTagDefinition

--- a/ghc-tags-core/lib/GhcTags/Stream.hs
+++ b/ghc-tags-core/lib/GhcTags/Stream.hs
@@ -20,6 +20,7 @@ import qualified Data.ByteString.Builder as BS
 import           Data.Functor (($>))
 import           Data.Text (Text)
 import           System.IO
+import           System.FilePath (equalFilePath)
 
 import           Pipes ((>->), (~>))
 import qualified Pipes as Pipes
@@ -63,7 +64,7 @@ combineTagsPipe compareFn modPath = go
        -> Pipes.Producer (Tag tk) m [Tag tk]
 
     go tag as
-      | tagFilePath tag == modPath = pure as
+      | tagFilePath tag `equalFilePath` modPath = pure as
 
     go tag as@(a : as')
       | otherwise = case a `compareFn` tag of

--- a/ghc-tags-core/test/Main.hs
+++ b/ghc-tags-core/test/Main.hs
@@ -3,6 +3,7 @@ module Main where
 import           Control.Exception
 import           Data.Bool
 import           Data.Monoid
+import           System.FilePath (normalise)
 
 import           Test.Tasty
 
@@ -18,8 +19,8 @@ main ::IO ()
 main = do
     -- useing 'IO' 'Monoid' instance
     mGoldenDir
-      <- doesGoldenDirectoryExist "test/golden"
-      <> doesGoldenDirectoryExist "ghc-tags-core/test/golden"
+      <- doesGoldenDirectoryExist (normalise "test/golden")
+      <> doesGoldenDirectoryExist (normalise "ghc-tags-core/test/golden")
 
     case mGoldenDir :: First FilePath of
       First Nothing ->

--- a/ghc-tags-core/test/Test/Tag.hs
+++ b/ghc-tags-core/test/Test/Tag.hs
@@ -15,6 +15,7 @@ import           Data.Function (on)
 import           Data.Functor.Identity
 import           Data.Foldable (traverse_)
 import           Data.List (nub, sortBy)
+import           System.FilePath (equalFilePath)
 
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
@@ -267,16 +268,16 @@ combineTags_identity (ArbTagsFromFile fp as) =
 --
 combineTags_preserve :: ArbTagsFromFile -> ArbTagList -> Bool
 combineTags_preserve (ArbTagsFromFile fp as) (ArbTagList bs) =
-       filter (\t -> tagFilePath t /= fp) (combineTags CTag.compareTags fp as bs)
+       filter (\t -> not $ tagFilePath t `equalFilePath` fp) (combineTags CTag.compareTags fp as bs)
     == 
-       filter (\t -> tagFilePath t /= fp) bs
+       filter (\t -> not $ tagFilePath t `equalFilePath` fp) bs
 
 
 -- | Substitutes all tags of the current file.
 --
 combineTags_substitution :: ArbTagsFromFile -> ArbTagList -> Bool
 combineTags_substitution (ArbTagsFromFile fp as) (ArbTagList bs) =
-       filter (\t -> tagFilePath t == fp) (combineTags CTag.compareTags fp as bs)
+       filter (\t -> tagFilePath t `equalFilePath` fp) (combineTags CTag.compareTags fp as bs)
     == 
        as
 

--- a/ghc-tags-plugin/lib/Plugin/GhcTags.hs
+++ b/ghc-tags-plugin/lib/Plugin/GhcTags.hs
@@ -249,15 +249,17 @@ updateTags Options { etags, filePath = Identity tagsFile }
                             ll <- map (succ . BS.length) . BSC.lines <$> BS.readFile sourcePath
 
                             let tags' :: [ETag]
-                                tags' = combineTags ETag.compareTags (fixFilePath cwd tagsDir sourcePath)
-                                          ( sortBy ETag.compareTags
-                                          . map ( ETag.withByteOffset ll
-                                                . fixTagFilePath cwd tagsDir
-                                                )
-                                          . mapMaybe (ghcTagToTag SingETag)
-                                          . getGhcTags
-                                          $ lmodule)
-                                          ( sortBy ETag.compareTags tags )
+                                tags' = combineTags
+                                          ETag.compareTags
+                                          (fixFilePath cwd tagsDir sourcePath)
+                                          (sortBy ETag.compareTags
+                                            . map ( ETag.withByteOffset ll
+                                                  . fixTagFilePath cwd tagsDir
+                                                  )
+                                            . mapMaybe (ghcTagToTag SingETag)
+                                            . getGhcTags
+                                            $ lmodule)
+                                          (sortBy ETag.compareTags tags)
 
                             BB.hPutBuilder writeHandle (ETag.formatETagsFile tags')
 


### PR DESCRIPTION
Both vim and emacs work well with not normalised paths in tag file (also
on Windows).  Tools like `ctags` even on Windows produce Unix style
paths.

Use `equalFilePath` for comparison of paths names, whcih does
normalisation, drops trailing path separator and on Windows makes the
paths lower case (fs on Windows is case insensistive).

Path normalisation will be done in `ghc-tags-plugin`.
