### PR TITLE
Type level annotations for CTags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ install:
 		      --lib \
 		      ghc-tags-plugin
 	rm ${ENV}
+	ghc-pkg describe --package-db=${PACKAGE_DB} ghc-tags-plugin | grep ^id | sed 's/^id: //'
 
 reinstall: uninstall install
 

--- a/ghc-tags-core/CHANGELOG.md
+++ b/ghc-tags-core/CHANGELOG.md
@@ -4,3 +4,5 @@
 
 * First version. Released on an unsuspecting world.
 * Normalise 'tagFilePath' for tags which are returned by the parsers.
+* Added `GhcTag`, some of the constructor contains type level information which
+  is used to form `CTagFields`.

--- a/ghc-tags-core/lib/GhcTags/CTag/Formatter.hs
+++ b/ghc-tags-core/lib/GhcTags/CTag/Formatter.hs
@@ -57,15 +57,11 @@ formatTag Tag { tagName, tagFilePath, tagAddr, tagKind, tagFields = TagFields ta
       BS.byteString . Text.encodeUtf8 . getExCommand $ exCommand     
 
     formatKindChar :: CTagKind -> Builder
-    formatKindChar NoKind = mempty
-    formatKindChar (CharKind c)
-                     | isAscii c = BS.charUtf8 '\t' <> BS.charUtf8 c
-                     | otherwise = BS.stringUtf8 "\tkind:" <> BS.charUtf8 c
-    formatKindChar (GhcKind ghcKind)
-                     | isAscii c = BS.charUtf8 '\t' <> BS.charUtf8 c
-                     | otherwise = BS.stringUtf8 "\tkind:" <> BS.charUtf8 c
-      where
-        c = ghcKindToChar ghcKind
+    formatKindChar tk =
+      case tagKindToChar tk of
+        Nothing -> mempty
+        Just c | isAscii c -> BS.charUtf8 '\t' <> BS.charUtf8 c
+               | otherwise -> BS.stringUtf8 "\tkind:" <> BS.charUtf8 c
 
 
 formatField :: TagField -> Builder

--- a/ghc-tags-core/lib/GhcTags/CTag/Parser.hs
+++ b/ghc-tags-core/lib/GhcTags/CTag/Parser.hs
@@ -124,12 +124,6 @@ parseTag =
     parseFields = TagFields <$> AT.sepBy parseField separator
 
 
-charToTagKind :: Char -> CTagKind
-charToTagKind c = case charToGhcKind c of
-    Nothing      -> CharKind c
-    Just ghcTag  -> GhcKind  ghcTag
-
-
 parseField :: Parser TagField
 parseField =
          TagField

--- a/ghc-tags-core/lib/GhcTags/CTag/Utils.hs
+++ b/ghc-tags-core/lib/GhcTags/CTag/Utils.hs
@@ -1,50 +1,56 @@
+{-# LANGUAGE GADTs #-}
+
 module GhcTags.CTag.Utils
-  ( ghcKindToChar
-  , charToGhcKind
+  ( tagKindToChar
+  , charToTagKind
   ) where
 
-import           GhcTags.Ghc
+import           GhcTags.Tag
 
-ghcKindToChar :: GhcKind -> Char
-ghcKindToChar tagKind = case tagKind of
-    TkTerm                    -> '`'
-    TkFunction                -> 'λ'
-    TkTypeConstructor         -> 'Λ'
-    TkDataConstructor         -> 'c'
-    TkGADTConstructor         -> 'g'
-    TkRecordField             -> 'r'
-    TkTypeSynonym             -> '≡'
-    TkTypeSignature           -> '⊢'
-    TkPatternSynonym          -> 'p'
-    TkTypeClass               -> 'C'
-    TkTypeClassMember         -> 'm'
-    TkTypeClassInstance       -> 'i'
-    TkTypeFamily              -> 'f'
-    TkTypeFamilyInstance      -> 'F'
-    TkDataTypeFamily          -> 'd'
-    TkDataTypeFamilyInstance  -> 'D'
-    TkForeignImport           -> 'I'
-    TkForeignExport           -> 'E'
+tagKindToChar :: CTagKind -> Maybe Char
+tagKindToChar tk = case tk of
+    TkTerm                    -> Just '`'
+    TkFunction                -> Just 'λ'
+    TkTypeConstructor         -> Just 'Λ'
+    TkDataConstructor         -> Just 'c'
+    TkGADTConstructor         -> Just 'g'
+    TkRecordField             -> Just 'r'
+    TkTypeSynonym             -> Just '≡'
+    TkTypeSignature           -> Just '⊢'
+    TkPatternSynonym          -> Just 'p'
+    TkTypeClass               -> Just 'C'
+    TkTypeClassMember         -> Just 'm'
+    TkTypeClassInstance       -> Just 'i'
+    TkTypeFamily              -> Just 'f'
+    TkTypeFamilyInstance      -> Just 'F'
+    TkDataTypeFamily          -> Just 'd'
+    TkDataTypeFamilyInstance  -> Just 'D'
+    TkForeignImport           -> Just 'I'
+    TkForeignExport           -> Just 'E'
+
+    CharKind c                -> Just c
+    NoKind                    -> Nothing
 
 
-charToGhcKind :: Char -> Maybe GhcKind
-charToGhcKind c = case c of
-     '`' -> Just TkTerm
-     'λ' -> Just TkFunction
-     'Λ' -> Just TkTypeConstructor
-     'c' -> Just TkDataConstructor
-     'g' -> Just TkGADTConstructor
-     'r' -> Just TkRecordField
-     '≡' -> Just TkTypeSynonym
-     '⊢' -> Just TkTypeSignature
-     'p' -> Just TkPatternSynonym
-     'C' -> Just TkTypeClass
-     'm' -> Just TkTypeClassMember
-     'i' -> Just TkTypeClassInstance
-     'f' -> Just TkTypeFamily
-     'F' -> Just TkTypeFamilyInstance
-     'd' -> Just TkDataTypeFamily
-     'D' -> Just TkDataTypeFamilyInstance
-     'I' -> Just TkForeignImport
-     'E' -> Just TkForeignExport
-     _   -> Nothing
+charToTagKind :: Char -> CTagKind
+charToTagKind c = case c of
+     '`' -> TkTerm
+     'λ' -> TkFunction
+     'Λ' -> TkTypeConstructor
+     'c' -> TkDataConstructor
+     'g' -> TkGADTConstructor
+     'r' -> TkRecordField
+     '≡' -> TkTypeSynonym
+     '⊢' -> TkTypeSignature
+     'p' -> TkPatternSynonym
+     'C' -> TkTypeClass
+     'm' -> TkTypeClassMember
+     'i' -> TkTypeClassInstance
+     'f' -> TkTypeFamily
+     'F' -> TkTypeFamilyInstance
+     'd' -> TkDataTypeFamily
+     'D' -> TkDataTypeFamilyInstance
+     'I' -> TkForeignImport
+     'E' -> TkForeignExport
+
+     _   -> CharKind c

--- a/ghc-tags-core/lib/GhcTags/Ghc.hs
+++ b/ghc-tags-core/lib/GhcTags/Ghc.hs
@@ -78,42 +78,24 @@ import           Name         ( nameOccName
 -- | Kind of the term.
 --
 data GhcTagKind
-  = GtkTerm
-  -- ^ @`@
-  | GtkFunction
-  -- ^ @λ@
-  | GtkTypeConstructor
-  -- ^ @Λ@
-  | GtkDataConstructor
-  -- ^ @c@
-  | GtkGADTConstructor
-  -- ^ @g@
-  | GtkRecordField
-  -- ^ @r@
-  | GtkTypeSynonym
-  -- ^ @≡@
-  | GtkTypeSignature
-  -- ^ @⊢@
-  | GtkPatternSynonym
-  -- ^ @p@
-  | GtkTypeClass
-  -- ^ @C@
-  | GtkTypeClassMember
-  -- ^ @m@
-  | GtkTypeClassInstance (HsType GhcPs)
-  -- ^ @i@
-  | GtkTypeFamily
-  -- ^ @f@
-  | GtkTypeFamilyInstance
-  -- ^ @F@
-  | GtkDataTypeFamily
-  -- ^ @d@
-  | GtkDataTypeFamilyInstance
-  -- ^ @D@
-  | GtkForeignImport
-  -- ^ @I@
-  | GtkForeignExport
-  -- ^ @E@
+    = GtkTerm
+    | GtkFunction
+    | GtkTypeConstructor
+    | GtkDataConstructor
+    | GtkGADTConstructor
+    | GtkRecordField
+    | GtkTypeSynonym
+    | GtkTypeSignature
+    | GtkPatternSynonym
+    | GtkTypeClass
+    | GtkTypeClassMember
+    | GtkTypeClassInstance (HsType GhcPs)
+    | GtkTypeFamily
+    | GtkTypeFamilyInstance
+    | GtkDataTypeFamily
+    | GtkDataTypeFamilyInstance
+    | GtkForeignImport
+    | GtkForeignExport
 
 
 -- | We can read names from using fields of type 'GHC.Hs.Extensions.IdP' (a type

--- a/ghc-tags-core/lib/GhcTags/Tag.hs
+++ b/ghc-tags-core/lib/GhcTags/Tag.hs
@@ -56,7 +56,7 @@ import           SrcLoc       ( SrcSpan (..)
                               )
 
 import           GhcTags.Ghc  ( GhcTag (..)
-                              , GhcKind (..)
+                              , GhcTagKind (..)
                               )
 
 --
@@ -82,7 +82,7 @@ newtype TagName = TagName { getTagName :: Text }
 
 
 -- | When we parse a `tags` file we can eithera find no kind or recognize the
--- kind of GhcKind or we store the found character kind.  This allows us to
+-- kind of GhcTagKind or we store the found character kind.  This allows us to
 -- preserve information from parsed tags files which were not created by
 -- `ghc-tags-plugin'
 --
@@ -343,7 +343,7 @@ ghcTagToTag sing GhcTag { gtSrcSpan, gtTag, gtKind, gtIsExported, gtFFI } =
 
           , tagKind       =
               case sing of
-                SingCTag -> fromGhcKind gtKind
+                SingCTag -> fromGhcTagKind gtKind
                 SingETag -> NoKind
 
           , tagDefinition = NoTagDefinition
@@ -361,24 +361,23 @@ ghcTagToTag sing GhcTag { gtSrcSpan, gtTag, gtKind, gtIsExported, gtFFI } =
           }
 
   where
-    fromGhcKind :: GhcKind -> CTagKind
-    fromGhcKind = \case
-      GKTerm                   -> TkTerm
-      GKFunction               -> TkFunction
-      GKTypeConstructor        -> TkTypeConstructor
-      GKDataConstructor        -> TkDataConstructor
-      GKGADTConstructor        -> TkGADTConstructor
-      GKRecordField            -> TkRecordField
-      GKTypeSynonym            -> TkTypeSynonym
-      GKTypeSignature          -> TkTypeSignature
-      GKPatternSynonym         -> TkPatternSynonym
-      GKTypeClass              -> TkTypeClass
-      GKTypeClassMember        -> TkTypeClassMember
-      GKTypeClassInstance {}   -> TkTypeClassInstance
-      GKTypeFamily             -> TkTypeFamily
-      GKTypeFamilyInstance     -> TkTypeFamilyInstance
-      GKDataTypeFamily         -> TkDataTypeFamily
-      GKDataTypeFamilyInstance -> TkDataTypeFamilyInstance
-      GKForeignImport          -> TkForeignImport
-      GKForeignExport          -> TkForeignExport
-      
+    fromGhcTagKind :: GhcTagKind -> CTagKind
+    fromGhcTagKind = \case
+      GtkTerm                   -> TkTerm
+      GtkFunction               -> TkFunction
+      GtkTypeConstructor        -> TkTypeConstructor
+      GtkDataConstructor        -> TkDataConstructor
+      GtkGADTConstructor        -> TkGADTConstructor
+      GtkRecordField            -> TkRecordField
+      GtkTypeSynonym            -> TkTypeSynonym
+      GtkTypeSignature          -> TkTypeSignature
+      GtkPatternSynonym         -> TkPatternSynonym
+      GtkTypeClass              -> TkTypeClass
+      GtkTypeClassMember        -> TkTypeClassMember
+      GtkTypeClassInstance {}   -> TkTypeClassInstance
+      GtkTypeFamily             -> TkTypeFamily
+      GtkTypeFamilyInstance     -> TkTypeFamilyInstance
+      GtkDataTypeFamily         -> TkDataTypeFamily
+      GtkDataTypeFamilyInstance -> TkDataTypeFamilyInstance
+      GtkForeignImport          -> TkForeignImport
+      GtkForeignExport          -> TkForeignExport

--- a/ghc-tags-core/lib/GhcTags/Tag.hs
+++ b/ghc-tags-core/lib/GhcTags/Tag.hs
@@ -86,43 +86,44 @@ newtype TagName = TagName { getTagName :: Text }
 -- preserve information from parsed tags files which were not created by
 -- `ghc-tags-plugin'
 --
+-- * 'TkTerm' - @`@
+-- * 'TkFunction' - @λ@
+-- * 'TkTypeConstructor' - @Λ@
+-- * 'TkDataConstructor' - @c@
+-- * 'TkGADTConstructor' - @g@
+-- * 'TkRecordField' - @r@
+-- * 'TkTypeSynonym' - @≡@
+-- * 'TkTypeSignature' - @⊢@
+-- * 'TkPatternSynonym' - @p@
+-- * 'TkTypeClass' - @C@
+-- * 'TkTypeClassMember' - @m@
+-- * 'TkTypeClassInstance' - @i@
+-- * 'TkTypeFamily' - @f@
+-- * 'TkTypeFamilyInstance' - @F@
+-- * 'TkDataTypeFamily' - @d@
+-- * 'TkDataTypeFamilyInstance' - @D@
+-- * 'TkForeignImport' - @I@
+-- * 'TkForeignExport' - @E@
+--
 data TagKind (tk :: TAG_KIND) where
     TkTerm                   :: TagKind CTAG
-    -- ^ @`@
     TkFunction               :: TagKind CTAG
-    -- ^ @λ@
     TkTypeConstructor        :: TagKind CTAG
-    -- ^ @Λ@
     TkDataConstructor        :: TagKind CTAG
-    -- ^ @c@
     TkGADTConstructor        :: TagKind CTAG
-    -- ^ @g@
     TkRecordField            :: TagKind CTAG
-    -- ^ @r@
     TkTypeSynonym            :: TagKind CTAG
-    -- ^ @≡@
     TkTypeSignature          :: TagKind CTAG
-    -- ^ @⊢@
     TkPatternSynonym         :: TagKind CTAG
-    -- ^ @p@
     TkTypeClass              :: TagKind CTAG
-    -- ^ @C@
     TkTypeClassMember        :: TagKind CTAG
-    -- ^ @m@
     TkTypeClassInstance      :: TagKind CTAG
-    -- ^ @i@
     TkTypeFamily             :: TagKind CTAG
-    -- ^ @f@
     TkTypeFamilyInstance     :: TagKind CTAG
-    -- ^ @F@
     TkDataTypeFamily         :: TagKind CTAG
-    -- ^ @d@
     TkDataTypeFamilyInstance :: TagKind CTAG
-    -- ^ @D@
     TkForeignImport          :: TagKind CTAG
-    -- ^ @I@
     TkForeignExport          :: TagKind CTAG
-    -- ^ @E@
     CharKind                 :: !Char -> TagKind CTAG
     NoKind                   :: TagKind tk
 

--- a/ghc-tags-core/test/Test/Tag/Generators.hs
+++ b/ghc-tags-core/test/Test/Tag/Generators.hs
@@ -6,7 +6,6 @@ module Test.Tag.Generators where
 
 import qualified Data.Char as Char
 import           Data.List as List
-import           Data.Maybe (isNothing)
 import           Data.Text   (Text)
 import qualified Data.Text as Text
 
@@ -16,7 +15,6 @@ import           Test.QuickCheck
 import           Test.QuickCheck.Instances.Text ()
 
 import           GhcTags.Tag
-import           GhcTags.CTag.Utils
 
 --
 -- Generators
@@ -69,40 +67,35 @@ fixAddr = fixText . Text.replace ";\"" ""
 wrap :: Char -> Text -> Text
 wrap c = Text.cons c . flip Text.snoc c
 
-genGhcKind :: Gen GhcKind
-genGhcKind = elements
-  [ TkTerm
-  , TkFunction
-  , TkTypeConstructor
-  , TkDataConstructor
-  , TkGADTConstructor
-  , TkRecordField
-  , TkTypeSynonym
-  , TkTypeSignature
-  , TkPatternSynonym
-  , TkTypeClass
-  , TkTypeClassMember
-  , TkTypeClassInstance
-  , TkTypeFamily
-  , TkTypeFamilyInstance
-  , TkDataTypeFamily
-  , TkDataTypeFamilyInstance
-  , TkForeignImport
-  , TkForeignExport
-  ]
-
 genTagKind :: SingTagKind tk -> Gen (TagKind tk)
 genTagKind SingETag = pure NoKind
 genTagKind SingCTag = oneof
-    [ pure NoKind
+    [ pure TkTerm
+    , pure TkFunction
+    , pure TkTypeConstructor
+    , pure TkDataConstructor
+    , pure TkGADTConstructor
+    , pure TkRecordField
+    , pure TkTypeSynonym
+    , pure TkTypeSignature
+    , pure TkPatternSynonym
+    , pure TkTypeClass
+    , pure TkTypeClassMember
+    , pure TkTypeClassInstance
+    , pure TkTypeFamily
+    , pure TkTypeFamilyInstance
+    , pure TkDataTypeFamily
+    , pure TkDataTypeFamilyInstance
+    , pure TkForeignImport
+    , pure TkForeignExport
     , CharKind <$> genChar
-    , GhcKind <$> genGhcKind
+    , pure NoKind
     ]
   where
     genChar = suchThat arbitrary
                        ( ((/= Char.Control) . Char.generalCategory)
                          /\ (/= ':')
-                         /\ (isNothing . charToGhcKind)
+                         /\ (not . flip elem ("`λΛcgr≡⊢pCmifFdDIE" :: String))
                        )
 
 shrinkTag' :: Tag tk -> [Tag tk]

--- a/ghc-tags-plugin/CHANGELOG.md
+++ b/ghc-tags-plugin/CHANGELOG.md
@@ -33,7 +33,10 @@
 
 * concurrency safety - protection `tags` file using a file lock
 
-## 0.1.6.0 -- 2020-03-21
+## 0.1.6.0 -- ?
 
 * support for etags files
 * various bug fixes
+* type level information (not type checked!), from the parsed tree, including:
+  type of instances (instance context & instance head), types of `GADTs`
+  constructors, rhs of type synonyms, kinds of type or data families.

--- a/ghc-tags-plugin/lib/Plugin/GhcTags.hs
+++ b/ghc-tags-plugin/lib/Plugin/GhcTags.hs
@@ -219,7 +219,7 @@ updateTags Options { etags, filePath = Identity tagsFile }
                       tags = map (fixTagFilePath cwd tagsDir)
                                                   -- fix file names
                            . sortBy compareTags   -- sort
-                           . mapMaybe (ghcTagToTag SingCTag)
+                           . mapMaybe (ghcTagToTag SingCTag dynFlags)
                                                   -- translate 'GhcTag' to 'Tag'
                            . getGhcTags           -- generate 'GhcTag's
                            $ lmodule
@@ -263,7 +263,7 @@ updateTags Options { etags, filePath = Identity tagsFile }
                                             . map ( ETag.withByteOffset ll
                                                   . fixTagFilePath cwd tagsDir
                                                   )
-                                            . mapMaybe (ghcTagToTag SingETag)
+                                            . mapMaybe (ghcTagToTag SingETag dynFlags)
                                             . getGhcTags
                                             $ lmodule)
                                           (sortBy ETag.compareTags tags)


### PR DESCRIPTION
Added `instance`, `type` and `Kind` ctag fields, which hold type level
information found in `HsModule GhcPs`.  This is not typed-checked information!
but useful anyway.

- Added type and (ghc) kind annotations
- Fixed haddocks
- Rename: GhcKing -> GhcTagKind
- Test conversion CTagKind <-> Char
- GhcKind type and TagKind
- Make the option parser more permissive
- Improve Makefile
- Improve loging output
