### PR TITLE
Simplify GhcTag fields

### DIFF
--- a/ghc-tags-core/lib/GhcTags/Ghc.hs
+++ b/ghc-tags-core/lib/GhcTags/Ghc.hs
@@ -16,8 +16,7 @@ module GhcTags.Ghc
 
 import           Data.Maybe    (mapMaybe)
 import           Data.Foldable (foldl')
-import           Data.Text   (Text)
-import qualified Data.Text as Text
+import           Data.ByteString (ByteString)
 
 -- Ghc imports
 import           BasicTypes   ( SourceText (..)
@@ -115,8 +114,8 @@ data GhcTagKind
 data GhcTag = GhcTag {
     gtSrcSpan    :: !SrcSpan
     -- ^ term location
-  , gtTag        :: !FastString
-    -- ^ tag's name
+  , gtTag        :: !ByteString
+    -- ^ utf8 encoded tag's name
   , gtKind       :: !GhcTagKind
     -- ^ tag's kind
   , gtIsExported :: !Bool
@@ -188,7 +187,7 @@ mkGhcTag :: Located RdrName
 mkGhcTag (L gtSrcSpan rdrName) gtKind gtIsExported =
     case rdrName of
       Unqual occName ->
-        GhcTag { gtTag = occNameFS occName
+        GhcTag { gtTag = fs_bs (occNameFS occName)
                , gtSrcSpan
                , gtKind
                , gtIsExported
@@ -196,7 +195,7 @@ mkGhcTag (L gtSrcSpan rdrName) gtKind gtIsExported =
                }
 
       Qual _ occName ->
-        GhcTag { gtTag = occNameFS occName
+        GhcTag { gtTag = fs_bs (occNameFS occName)
                , gtSrcSpan
                , gtKind
                , gtIsExported
@@ -205,7 +204,7 @@ mkGhcTag (L gtSrcSpan rdrName) gtKind gtIsExported =
 
       -- Orig is the only one we are interested in
       Orig _ occName ->
-        GhcTag { gtTag = occNameFS occName
+        GhcTag { gtTag = fs_bs (occNameFS occName)
                , gtSrcSpan
                , gtKind
                , gtIsExported
@@ -213,7 +212,7 @@ mkGhcTag (L gtSrcSpan rdrName) gtKind gtIsExported =
                }
 
       Exact eName -> 
-        GhcTag { gtTag = occNameFS $ nameOccName eName
+        GhcTag { gtTag = fs_bs (occNameFS (nameOccName eName))
                , gtSrcSpan
                , gtKind
                , gtIsExported

--- a/ghc-tags-core/lib/GhcTags/Ghc.hs
+++ b/ghc-tags-core/lib/GhcTags/Ghc.hs
@@ -120,7 +120,7 @@ data GhcTag = GhcTag {
     -- ^ tag's kind
   , gtIsExported :: !Bool
     -- ^ 'True' iff the term is exported
-  , gtFFI        :: !(Maybe Text)
+  , gtFFI        :: !(Maybe String)
     -- ^ @ffi@ import
   }
 
@@ -386,7 +386,7 @@ getGhcTags (L _ HsModule { hsmodDecls, hsmodExports }) =
                 case sourceText of
                   NoSourceText -> tag
                   -- TODO: add header information from '_mheader'
-                  SourceText s -> tag { gtFFI = Just (Text.pack s) }
+                  SourceText s -> tag { gtFFI = Just s }
               : tags
             where
               tag = mkGhcTag' fd_name GtkForeignImport

--- a/ghc-tags-core/lib/GhcTags/Tag.hs
+++ b/ghc-tags-core/lib/GhcTags/Tag.hs
@@ -344,7 +344,7 @@ ghcTagToTag sing dynFlags GhcTag { gtSrcSpan, gtTag, gtKind, gtIsExported, gtFFI
       UnhelpfulSpan {} -> Nothing
       RealSrcSpan realSrcSpan ->
         Just $ Tag
-          { tagName       = TagName tagName 
+          { tagName       = TagName (Text.decodeUtf8 gtTag)
           , tagFilePath   = TagFilePath
                           $ Text.decodeUtf8
                           $ fs_bs
@@ -367,8 +367,6 @@ ghcTagToTag sing dynFlags GhcTag { gtSrcSpan, gtTag, gtKind, gtIsExported, gtFFI
           }
 
   where
-    tagName = Text.decodeUtf8 $ fs_bs gtTag
-
     fromGhcTagKind :: GhcTagKind -> CTagKind
     fromGhcTagKind = \case
       GtkTerm                   -> TkTerm

--- a/ghc-tags-core/lib/GhcTags/Tag.hs
+++ b/ghc-tags-core/lib/GhcTags/Tag.hs
@@ -338,7 +338,8 @@ combineTags compareFn modPath = go
 
 -- | Create a 'Tag' from 'GhcTag'.
 --
-ghcTagToTag :: SingTagKind tk -> DynFlags -> GhcTag -> Maybe (Tag tk)
+ghcTagToTag :: SingTagKind tk -> DynFlags
+            -> GhcTag -> Maybe (Tag tk)
 ghcTagToTag sing dynFlags GhcTag { gtSrcSpan, gtTag, gtKind, gtIsExported, gtFFI } =
     case gtSrcSpan of
       UnhelpfulSpan {} -> Nothing
@@ -406,7 +407,7 @@ ghcTagToTag sing dynFlags GhcTag { gtSrcSpan, gtTag, gtKind, gtIsExported, gtFFI
         TagFields $
           case gtFFI of
             Nothing  -> mempty
-            Just ffi -> [TagField "ffi" ffi]
+            Just ffi -> [TagField "ffi" (Text.pack ffi)]
 
 
     -- 'TagFields' from 'GhcTagKind'


### PR DESCRIPTION
Stay close to how `GHC` is representing data (term names, ffi), without
conversion.  Conversion to `Text` is done when forming a `Tag`. 

- GhcTag: use String to represent gtFFI
- GhcTag: use ByteString to represent tag name
